### PR TITLE
Update .gitignore and expand README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,24 @@
 # API Keys - DO NOT COMMIT
 HopDaStockForREAL/Secrets.plist
 
-# Python framework (if ever re-added)
-HopDaStockForREAL/Frameworks/
-
 # Xcode
 *.xcuserstate
 xcuserdata/
+*.xccheckout
+*.xcscmblueprint
+DerivedData/
+build/
+
+# macOS
+.DS_Store
+*.swp
+*~
+
+# Python (if ever re-added)
+HopDaStockForREAL/Frameworks/
+__pycache__/
+*.pyc
+
+# IDE
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,19 +1,78 @@
 # HopDaStock
-## Proud to announce the release of HopDaStock
-This project was a lot of fun to make. I learned so much about swift, python interpretors, embededd systems, and linear regression models. 
 
-### Installation 
-#### Clone repository to local machine, and open via Xcode
+A native macOS stock data viewer built with SwiftUI.
 
-### Features
-- Uses AlphaApi to fetch the user defined stocks data, and uses my Linear Regression Model to predict the direction of the stock based on it's previous Open/Close prices
-- Error Handling: Added exceptions and spelling checks to ensure that
-  - 1. The user defined stock symbol exists
-  - 2. We have remaining API calls (I was not paying for premium API access)
+## Features
 
+- **Real-time Stock Data** - Fetches daily stock prices from Alpha Vantage API
+- **Clean Interface** - Simple, focused UI for viewing open/close prices
+- **Search** - Look up any stock by symbol (AAPL, GOOGL, MSFT, etc.)
+- **Error Handling** - Validates stock symbols and handles API errors gracefully
 
-### Screenshots 
+## Screenshots
 
-<img width="929" alt="Screenshot 2025-02-13 at 11 40 37 AM" src="https://github.com/user-attachments/assets/456829b9-d494-4cb8-9a04-102dc8cc5669" />
-<img width="930" alt="Screenshot 2025-02-13 at 11 40 48 AM" src="https://github.com/user-attachments/assets/561dd50c-4eed-4957-8a69-cce79a483bf6" />
-<img width="933" alt="Screenshot 2025-02-13 at 11 40 23 AM" src="https://github.com/user-attachments/assets/4bf6af30-8723-433a-a5d1-f3df9402309e" />
+<img width="929" alt="Screenshot 2025-02-13 at 11 40 37 AM" src="https://github.com/user-attachments/assets/456829b9-d494-4cb8-9a04-102dc8cc5669" />
+
+## Requirements
+
+- macOS 13.0+
+- Xcode 15.0+
+- Alpha Vantage API key (free tier available)
+
+## Installation
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/BrandonGarate177/HopDaStock.git
+   cd HopDaStock
+   ```
+
+2. Get a free API key from [Alpha Vantage](https://www.alphavantage.co/support/#api-key)
+
+3. Create your secrets file:
+   ```bash
+   cp HopDaStockForREAL/Secrets.plist.template HopDaStockForREAL/Secrets.plist
+   ```
+
+4. Edit `HopDaStockForREAL/Secrets.plist` and add your API key:
+   ```xml
+   <key>ALPHA_VANTAGE_API_KEY</key>
+   <string>YOUR_API_KEY_HERE</string>
+   ```
+
+5. Open `HopDaStock.xcodeproj` in Xcode and run
+
+## Project Structure
+
+```
+HopDaStock/
+├── HopDaStockForREAL/          # Main app source
+│   ├── HopDaStockApp.swift     # App entry point
+│   ├── StockView.swift         # Main UI view
+│   ├── StockViewModel.swift    # View model (business logic)
+│   ├── StockDataPoint.swift    # Data model
+│   ├── StockService.swift      # API service layer
+│   ├── Secrets.plist.template  # API key template
+│   └── Assets.xcassets/        # App icons and colors
+├── HopDaStockForREALTests/     # Unit tests
+└── HopDaStockUITests/          # UI tests
+```
+
+## Architecture
+
+This app follows the **MVVM (Model-View-ViewModel)** pattern:
+
+| Layer | File | Responsibility |
+|-------|------|----------------|
+| **Model** | `StockDataPoint.swift` | Data structure for stock prices |
+| **View** | `StockView.swift` | SwiftUI interface |
+| **ViewModel** | `StockViewModel.swift` | State management, coordinates data flow |
+| **Service** | `StockService.swift` | API calls and JSON parsing |
+
+## API Usage
+
+This app uses the [Alpha Vantage API](https://www.alphavantage.co/) for stock data. The free tier allows 25 requests per day.
+
+## License
+
+MIT License - feel free to use this code for your own projects.


### PR DESCRIPTION
Add comprehensive .gitignore entries for Xcode, macOS, Python artifacts, and IDE folders to avoid committing build/user/temporary files. Expand README with a concise project summary, features, requirements, installation steps (including creating HopDaStockForREAL/Secrets.plist and Alpha Vantage API key), project structure, architecture (MVVM), API usage limits, and license to improve onboarding and developer documentation.